### PR TITLE
MBG - Don't quit to menu when pressing H key while not recording

### DIFF
--- a/src/MarbleWorld.hx
+++ b/src/MarbleWorld.hx
@@ -915,11 +915,6 @@ class MarbleWorld extends Scheduler {
 			return;
 		}
 
-		if (Key.isDown(Key.H)) {
-			this.isWatching = true;
-			this.restart();
-		}
-
 		this.updateTexts();
 	}
 


### PR DESCRIPTION
This allows me to enter my name in the end box lmao

I don't think this hotkey is needed - it's not documented (I don't think) and it could cause people to accidentally lose runs if they happen to be recording just by hitting H by accident. And if they wanted to save it as a blooper, it disappears after the run is over. Just letting the run be saved normally and watching after is more natural

Also some notes, I had to remove zyheaps from `compile.hxml` to get it to compile and it also updated `data\tmp\cache.dat`, not sure what that's about but if it's consistent then it should probably be committed to the repo