### PR TITLE
MBP - Don't support old replays to prevent the replay browser from crashing

### DIFF
--- a/src/Replay.hx
+++ b/src/Replay.hx
@@ -442,6 +442,10 @@ class Replay {
 			Console.log("Replay loading failed: unknown version");
 			return false;
 		}
+		if (replayVersion < 5) { // first version with headers
+			Console.log('Replay loading failed: version ${replayVersion} does not have a header');
+			return false;
+		}
 		var nameLength = data.get(1);
 		this.name = data.getString(2, nameLength);
 		var missionLength = data.get(2 + nameLength);
@@ -473,6 +477,10 @@ class Replay {
 		var replayVersion = data.get(0);
 		if (replayVersion > version) {
 			Console.log("Replay loading failed: unknown version");
+			return false;
+		}
+		if (replayVersion < 5) { // first version with headers
+			Console.log('Replay loading failed: version ${replayVersion} does not have a header');
 			return false;
 		}
 		var nameLength = data.get(1);


### PR DESCRIPTION
I had some MBGHaxe replays lying around in the folder when running MBP Haxe, and opening the replay browser showed garbage titles and shortly crashed. This PR detects replays with an old version and discards them. In order to support reading these files we'd need to make separate code paths, and that'd also slow down the replay browser since what is now header data used to be stored inside the compressed data and that would need to be decompressed. I didn't feel like doing that at the moment, so for now this solution at least prevents the crash which I'd say is better than no solution.