### PR TITLE
MBP - Small Fixes

### DIFF
--- a/src/MarbleWorld.hx
+++ b/src/MarbleWorld.hx
@@ -1480,7 +1480,7 @@ class MarbleWorld extends Scheduler {
 
 		// Show a notification (and play a sound) based on the gems remaining
 		if (this.gemCount == this.totalGems) {
-			string = "You have all the gems, head for the finish!";
+			string = "You have all the diamonds, head for the finish!";
 			// if (!this.rewinding)
 			AudioManager.playSound(ResourceLoader.getResource('data/sound/gotallgems.wav', ResourceLoader.getAudio, this.soundResources));
 
@@ -1491,13 +1491,13 @@ class MarbleWorld extends Scheduler {
 			// 	this.touchFinish(completionOfImpact);
 			// }
 		} else {
-			string = "You picked up a gem.  ";
+			string = "You picked up a diamond.  ";
 
 			var remaining = this.totalGems - this.gemCount;
 			if (remaining == 1) {
-				string += "Only one gem to go!";
+				string += "Only one diamond to go!";
 			} else {
-				string += '${remaining} gems to go!';
+				string += '${remaining} diamonds to go!';
 			}
 
 			// if (!this.rewinding)
@@ -1634,7 +1634,7 @@ class MarbleWorld extends Scheduler {
 
 		if (this.gemCount < this.totalGems) {
 			AudioManager.playSound(ResourceLoader.getResource('data/sound/missinggems.wav', ResourceLoader.getAudio, this.soundResources));
-			displayAlert("You can't finish without all the gems!!");
+			displayAlert("You can't finish without all the diamonds!!");
 		} else {
 			this.endPad.spawnFirework(this.timeState);
 			this.finishTime = this.timeState.clone();

--- a/src/gui/OptionsDlg.hx
+++ b/src/gui/OptionsDlg.hx
@@ -328,6 +328,9 @@ class OptionsDlg extends GuiImage {
 			remapDlg.remapCallback = (key) -> {
 				MarbleGame.canvas.popDialog(remapDlg);
 
+				if (key == Key.ESCAPE)
+					return;
+
 				var conflicting = getConflictingBinding(bindingName, key);
 				if (conflicting == null) {
 					ctrl.txtCtrl.text.text = Util.getKeyForButton2(key);

--- a/src/gui/RemapDlg.hx
+++ b/src/gui/RemapDlg.hx
@@ -43,9 +43,9 @@ class RemapDlg extends GuiControl {
 	public override function update(dt:Float, mouseState:MouseState) {
 		super.update(dt, mouseState);
 		for (i in 0...1024) {
-			if (i == 5)
+			if (i == Key.MOUSE_WHEEL_DOWN || i == Key.MOUSE_WHEEL_UP)
 				continue;
-			if (Key.isDown(i)) {
+			if (Key.isPressed(i)) {
 				remapCallback(i);
 			}
 		}


### PR DESCRIPTION
* Changed "gem" to "diamond" to match the rest of the names being MBP names
    * I actually prefer the opposite lol, where everything has MBG names (like they did in PQ). I made [a branch](https://github.com/thearst3rd/MBHaxe/tree/vanilla-powerup-names) which has everything renamed including levels/help triggers/etc - I figure you don't want it in MBHaxe to make it more true to MBP but I'll let you know about it in case you do
* Escape now cancels remapping, rather than mapping the action to the escape key
* One of the mouse wheel directions was being filtered from remapping (since they cause issues) but not the other, now they're both filtered