### PR TITLE
MBP - Make end screen gold/ultimate colors consistent with the rest of the menus

### DIFF
--- a/src/gui/EndGameGui.hx
+++ b/src/gui/EndGameGui.hx
@@ -209,11 +209,11 @@ class EndGameGui extends GuiControl {
 		var text = '<font color="#FFFFFF" face="DomCasual32"><p align="center">';
 		// Check for ultimate time TODO
 		if (mission.ultimateTime > 0 && timeState.gameplayClock < mission.ultimateTime) {
-			text += 'You beat the <font color="#FFDD22">Ultimate</font> Time!';
+			text += 'You beat the <font color="#FFCC33">Ultimate</font> Time!';
 		} else {
 			if (mission.goldTime > 0 && timeState.gameplayClock < mission.goldTime) {
 				if (mission.game == "gold" || mission.game.toLowerCase() == "ultra")
-					text += 'You beat the <font color="#FFCC00">Gold</font> Time!';
+					text += 'You beat the <font color="#FFFF00">Gold</font> Time!';
 				else
 					text += 'You beat the <font color="#CCCCCC">Platinum</font> Time!';
 			} else {
@@ -258,11 +258,11 @@ class EndGameGui extends GuiControl {
 
 		for (i in 0...5) {
 			if (scoreData[i].time < mission.ultimateTime) {
-				lineelems[i].text.text = '<font color="#FFDD22">${Util.formatTime(scoreData[i].time)}</font>';
+				lineelems[i].text.text = '<font color="#FFCC33">${Util.formatTime(scoreData[i].time)}</font>';
 			} else {
 				if (scoreData[i].time < mission.goldTime) {
 					if (mission.game == "gold" || mission.game.toLowerCase() == "ultra")
-						lineelems[i].text.text = '<font color="#FFCC00">${Util.formatTime(scoreData[i].time)}</font>';
+						lineelems[i].text.text = '<font color="#FFFF00">${Util.formatTime(scoreData[i].time)}</font>';
 					else
 						lineelems[i].text.text = '<font color="#CCCCCC">${Util.formatTime(scoreData[i].time)}</font>';
 				} else {
@@ -274,7 +274,7 @@ class EndGameGui extends GuiControl {
 		var leftColumn = new GuiMLText(domcasual24, mlFontLoader);
 		leftColumn.text.lineSpacing = 5;
 		leftColumn.text.textColor = 0xFFFFFF;
-		leftColumn.text.text = 'Par Time:<br/>${mission.game == "gold" || mission.game.toLowerCase() == "ultra" ? '<font color="#FFCC00">Gold Time:</font>' : '<font color="#CCCCCC">Platinum Time:</font>'}<br/>${mission.ultimateTime != 0 ? '<font color="#FFDD22">Ultimate Time:</font><br/>' : ''}<font face="Arial14"><br/></font><font color="#FFFFFF" face="DomCasual24">Time Passed:<br/>Clock Bonuses:</font>';
+		leftColumn.text.text = 'Par Time:<br/>${mission.game == "gold" || mission.game.toLowerCase() == "ultra" ? '<font color="#FFFF00">Gold Time:</font>' : '<font color="#CCCCCC">Platinum Time:</font>'}<br/>${mission.ultimateTime != 0 ? '<font color="#FFCC33">Ultimate Time:</font><br/>' : ''}<font face="Arial14"><br/></font><font color="#FFFFFF" face="DomCasual24">Time Passed:<br/>Clock Bonuses:</font>';
 		leftColumn.text.filter = new DropShadow(1.414, 0.785, 0x7777777F, 1, 0, 0.4, 1, true);
 		leftColumn.position = new Vector(25, 165);
 		leftColumn.extent = new Vector(293, 211);
@@ -286,7 +286,7 @@ class EndGameGui extends GuiControl {
 		var rightColumn = new GuiMLText(domcasual24, mlFontLoader);
 		rightColumn.text.lineSpacing = 5;
 		rightColumn.text.textColor = 0xFFFFFF;
-		rightColumn.text.text = '${Util.formatTime(mission.qualifyTime == Math.POSITIVE_INFINITY ? 5999.999 : mission.qualifyTime)}<br/><font color="${mission.game == "gold" || mission.game.toLowerCase() == "ultra" ? '#FFCC00' : '#CCCCCC'}">${Util.formatTime(mission.goldTime)}</font><br/>${mission.ultimateTime != 0 ? '<font color="#FFDD22">${Util.formatTime(mission.ultimateTime)}</font><br/>' : ''}<font face="Arial14"><br/></font><font color="#FFFFFF" face="DomCasual24">${Util.formatTime(elapsedTime)}<br/>${Util.formatTime(bonusTime)}</font>';
+		rightColumn.text.text = '${Util.formatTime(mission.qualifyTime == Math.POSITIVE_INFINITY ? 5999.999 : mission.qualifyTime)}<br/><font color="${mission.game == "gold" || mission.game.toLowerCase() == "ultra" ? '#FFFF00' : '#CCCCCC'}">${Util.formatTime(mission.goldTime)}</font><br/>${mission.ultimateTime != 0 ? '<font color="#FFCC33">${Util.formatTime(mission.ultimateTime)}</font><br/>' : ''}<font face="Arial14"><br/></font><font color="#FFFFFF" face="DomCasual24">${Util.formatTime(elapsedTime)}<br/>${Util.formatTime(bonusTime)}</font>';
 		rightColumn.text.filter = new DropShadow(1.414, 0.785, 0xffffff, 1, 0, 0.4, 1, true);
 		rightColumn.position = new Vector(235, 165);
 		rightColumn.extent = new Vector(293, 211);
@@ -332,10 +332,10 @@ class EndGameGui extends GuiControl {
 
 				for (i in 0...5) {
 					if (scoreData[i].time < mission.ultimateTime) {
-						lineelems[i].text.text = '<font color="#FFDD22">${Util.formatTime(scoreData[i].time)}</font>';
+						lineelems[i].text.text = '<font color="#FFCC33">${Util.formatTime(scoreData[i].time)}</font>';
 					} else {
 						if (scoreData[i].time < mission.goldTime) {
-							lineelems[i].text.text = '<font color="${mission.game == "gold" || mission.game.toLowerCase() == "ultra" ? '#FFCC00' : '#CCCCCC'}">${Util.formatTime(scoreData[i].time)}</font>';
+							lineelems[i].text.text = '<font color="${mission.game == "gold" || mission.game.toLowerCase() == "ultra" ? '#FFFF00' : '#CCCCCC'}">${Util.formatTime(scoreData[i].time)}</font>';
 						} else {
 							lineelems[i].text.text = '${Util.formatTime(scoreData[i].time)}';
 						}

--- a/src/gui/PlayMissionGui.hx
+++ b/src/gui/PlayMissionGui.hx
@@ -783,7 +783,7 @@ class PlayMissionGui extends GuiImage {
 				if (topScore.time < currentMission.ultimateTime) {
 					scoreColor = "#FFCC33";
 				} else if (topScore.time < currentMission.goldTime) {
-					if (currentMission.game == "gold" || currentMission.game == "Ultra")
+					if (currentMission.game == "gold" || currentMission.game.toLowerCase() == "ultra")
 						scoreColor = "#FFFF00"
 					else
 						scoreColor = "#CCCCCC";


### PR DESCRIPTION
This is a subjective commit, and might deviate from vanilla MBP (I haven't checked), so feel free to reject it if you don't want it. The EndGameGui challenge time colors looked wrong, particularly Gold times actually looked more orange than Ultimate times which made them hard to differentiate.

I confirmed that `FFFF00` for gold, `FFCC33` for ultimate, and `CCCCCC` for platinum are the colors used by PQ, and they are the colors used by the PlayMissionGui in MBHaxe. So I updated the EndGameGui to use those same colors as well.

Comparisons:

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/7307599/218644451-41cb3fc3-76d5-4720-8aef-eb0b9c60feba.png) | ![image](https://user-images.githubusercontent.com/7307599/218644487-22060a1c-ac5d-4187-bb4d-525d2b3dffab.png) |
| ![image](https://user-images.githubusercontent.com/7307599/218645709-395827e5-75c7-46f9-b402-079bde8c96a1.png) | ![image](https://user-images.githubusercontent.com/7307599/218645883-9433961a-51f8-4ad0-9448-aa6c77f7840d.png) |

The gold times are much easier to read on the orange background, and easier to tell it's the "gold" time by the color. Maybe though, the ultimate times are a bit harder to read, since I made them slightly less bright and the orange-on-orange doesn't help. It does match the PlayMissionGui now:

| Before and After |
| --- |
| ![image](https://user-images.githubusercontent.com/7307599/218645167-9aa9db7d-f9cf-49c7-96eb-aadfd2cb573a.png) |
| ![image](https://user-images.githubusercontent.com/7307599/218646372-3bd7e62f-2795-4f53-8f3b-79656ee5ba27.png) |


Also fixed a small bug where the best time could show using the platinum color instead of the gold color on MBU on the PlayMissionGui.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/7307599/218645244-bda3f70d-3e80-4435-8fc6-e01746556e19.png) | ![image](https://user-images.githubusercontent.com/7307599/218645296-41819869-f4d9-4ded-a00d-9d60b9735a9c.png) |