### PR TITLE
MBP - Don't pause when hitting restart button from EndGameGui on js

### DIFF
--- a/src/MarbleWorld.hx
+++ b/src/MarbleWorld.hx
@@ -1701,7 +1701,6 @@ class MarbleWorld extends Scheduler {
 		}, (sender) -> {
 			var restartGameCode = () -> {
 				MarbleGame.canvas.popDialog(egg);
-				this.setCursorLock(true);
 				this.restart(true);
 				#if js
 				pointercontainer.hidden = true;


### PR DESCRIPTION
Fixes slightly annoying bug on js where hitting the restart button on the EndGameGui would cause the game to instantly be paused (and your cursor was locked so you needed to unlock it to unpause). It seems the cursor was being locked twice, causing the weirdness, so I got rid of one of them.