### PR TITLE
MBP - Fix wrong color in Best Time for some MBU levels

### DIFF
--- a/src/gui/PlayMissionGui.hx
+++ b/src/gui/PlayMissionGui.hx
@@ -783,7 +783,7 @@ class PlayMissionGui extends GuiImage {
 				if (topScore.time < currentMission.ultimateTime) {
 					scoreColor = "#FFCC33";
 				} else if (topScore.time < currentMission.goldTime) {
-					if (currentMission.game == "gold" || currentMission.game == "Ultra")
+					if (currentMission.game == "gold" || currentMission.game.toLowerCase() == "ultra")
 						scoreColor = "#FFFF00"
 					else
 						scoreColor = "#CCCCCC";


### PR DESCRIPTION
Pulled this line from #12. This should be consistent with actual 1.7.42:

If you beat the gold time of an MBU level but not the ultimate time, the color next to "Best Time" would sometimes be platinum rather than gold. This fixes that

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/7307599/218645244-bda3f70d-3e80-4435-8fc6-e01746556e19.png) | ![image](https://user-images.githubusercontent.com/7307599/218645296-41819869-f4d9-4ded-a00d-9d60b9735a9c.png) |

Actual 1.7.42 screenshot for reference:

![image](https://user-images.githubusercontent.com/7307599/218903963-81cb382b-e53c-4730-bf6b-0dfb36594249.png)
