### PR TITLE
Skip the null holes that remove() and single player leave behind

### DIFF
--- a/src/collision/GridBroadphase.hx
+++ b/src/collision/GridBroadphase.hx
@@ -246,7 +246,11 @@ class GridBroadphase {
 		for (i in xStart...xEnd) {
 			for (j in yStart...yEnd) {
 				for (surfIdx in cells[16 * i + j]) {
-					var surf = objects[surfIdx].object;
+					// remove() nulls the slot but keeps the index; build() skips these too.
+					var proxy = objects[surfIdx];
+					if (proxy == null)
+						continue;
+					var surf = proxy.object;
 					if (surf.key == searchKey)
 						continue;
 					surf.key = searchKey;

--- a/src/gui/PlayGui.hx
+++ b/src/gui/PlayGui.hx
@@ -1077,7 +1077,8 @@ class PlayGui {
 		gemCountNumbers[4].anim.visible = false;
 		gemCountNumbers[5].anim.visible = false;
 
-		var off = playerList[0].us ? 10 : 0;
+		// playerList is multiplayer-only, so it is empty in single player.
+		var off = (playerList.length > 0 && playerList[0].us) ? 10 : 0;
 
 		gemCountNumbers[0].anim.currentFrame = off + collectedHundredths;
 		gemCountNumbers[1].anim.currentFrame = off + collectedTenths;


### PR DESCRIPTION
Two unguarded reads that throw `Null access` every frame. In both cases the surrounding code already checks the same condition elsewhere.

**`GridBroadphase.boundingSearch`** — `remove()` nulls `objects[proxy.index]` and keeps the index (`// Preserve indices pls`), so a cell can name a null slot. `build()` skips those holes when walking the same array; this loop doesn't.

**`PlayGui.formatGemHuntCounter`** — `playerList` is only populated in multiplayer: `initPlayerList()` is gated on `isMultiplayer`, `addPlayer()` needs `playerListCtrl != null`. Single player leaves it empty, so `playerList[0].us` derefs null on every restart.

Neither crashes — `System.hl.hx` catches per frame, so the game stops rendering and keeps throwing.

Measured on a Gem Hunt level: ~198k throws/40s from the broadphase, ~250k/30s from the counter, both to zero with these guards.